### PR TITLE
Removed register limits and optimization call.

### DIFF
--- a/src/com/holycityaudio/SpinCAD/SpinCADFrame.java
+++ b/src/com/holycityaudio/SpinCAD/SpinCADFrame.java
@@ -384,7 +384,8 @@ public class SpinCADFrame extends JFrame {
 		mntmCopyToClipboard.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent arg0) {
 				eeprom.patch[bankIndex].patchModel.sortAlignGen();
-				eeprom.patch[bankIndex].patchModel.getRenderBlock().optimizeProgram(1);
+				// GSW remove optimization for now
+				// eeprom.patch[bankIndex].patchModel.getRenderBlock().optimizeProgram(1);
 				StringSelection stringSelection = new StringSelection (eeprom.patch[bankIndex].cb.getComments() + eeprom.patch[bankIndex].patchModel.getRenderBlock().getProgramListing(1));
 				Clipboard clpbrd = Toolkit.getDefaultToolkit ().getSystemClipboard ();
 				clpbrd.setContents (stringSelection, null);	

--- a/src/org/andrewkilpatrick/elmGen/instructions/LoadAccumulator.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/LoadAccumulator.java
@@ -38,10 +38,11 @@ public class LoadAccumulator extends Instruction {
 	 * @param addr the address to load into ACC (0-63)
 	 */
 	public LoadAccumulator(int addr) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		this.addr = addr;
 	}
 	

--- a/src/org/andrewkilpatrick/elmGen/instructions/Maxx.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/Maxx.java
@@ -42,10 +42,11 @@ public class Maxx extends Instruction {
 	 * @param scale the amount to scale the reg value before the comparison
 	 */
 	public Maxx(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;

--- a/src/org/andrewkilpatrick/elmGen/instructions/Mulx.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/Mulx.java
@@ -39,10 +39,11 @@ public class Mulx extends Instruction {
 	 * @param addr the register address to multiply with ACC
 	 */
 	public Mulx(int addr) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		this.addr = addr;
 	}
 	

--- a/src/org/andrewkilpatrick/elmGen/instructions/ReadRegister.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/ReadRegister.java
@@ -42,10 +42,11 @@ public class ReadRegister extends Instruction {
 	 * @param scale the amount to scale the register
 	 */
 	public ReadRegister(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		// GSW removing limitation on registers
+		// if(addr < 0 || addr > 63) {
+//			throw new IllegalArgumentException("addr out of range: " + addr +
+	//				" - valid range: 0 - 63");
+		// }
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;

--- a/src/org/andrewkilpatrick/elmGen/instructions/ReadRegisterFilter.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/ReadRegisterFilter.java
@@ -44,10 +44,11 @@ public class ReadRegisterFilter extends Instruction {
 	 * @param scale the amount to scale the reg value before the comparison
 	 */
 	public ReadRegisterFilter(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;

--- a/src/org/andrewkilpatrick/elmGen/instructions/WriteRegister.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/WriteRegister.java
@@ -43,19 +43,20 @@ public class WriteRegister extends Instruction {
 	 * @param scale the amount to scale the ACC after the write
 	 */
 	public WriteRegister(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
+//		if(addr < 0 || addr > 63) {
 //			throw new IllegalArgumentException("addr out of range: " + addr + " - valid range: 0 - 63");
 	// GSW added for integration with SpinCAD Designer
 	// there's probably a better way to handle it at a higher level
-			JFrame frame = new JFrame();
-			JOptionPane.showMessageDialog(
-					frame,
-					"Too many registers used!\n" + 
-							"Remove some blocks." ,
-							"Whoopsie!",
-							JOptionPane.OK_OPTION);
-
-		}
+	// removing this to allow going over FV-1 limits
+	//		JFrame frame = new JFrame();
+	//		JOptionPane.showMessageDialog(
+	//				frame,
+	//				"Too many registers used!\n" + 
+	//						"Remove some blocks." ,
+	//						"Whoopsie!",
+	//						JOptionPane.OK_OPTION);
+	//
+//		}
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;

--- a/src/org/andrewkilpatrick/elmGen/instructions/WriteRegisterHighshelf.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/WriteRegisterHighshelf.java
@@ -44,10 +44,11 @@ public class WriteRegisterHighshelf extends Instruction {
 	 */
 
 	public WriteRegisterHighshelf(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;

--- a/src/org/andrewkilpatrick/elmGen/instructions/WriteRegisterLowshelf.java
+++ b/src/org/andrewkilpatrick/elmGen/instructions/WriteRegisterLowshelf.java
@@ -46,10 +46,11 @@ public class WriteRegisterLowshelf extends Instruction {
 	 */
 
 	public WriteRegisterLowshelf(int addr, double scale) {
-		if(addr < 0 || addr > 63) {
-			throw new IllegalArgumentException("addr out of range: " + addr +
-					" - valid range: 0 - 63");
-		}
+		/// GSW removing register limits
+		// if(addr < 0 || addr > 63) {
+		//	throw new IllegalArgumentException("addr out of range: " + addr +
+		//			" - valid range: 0 - 63");
+		// }
 		checkS114(scale);
 		this.addr = addr;
 		this.scale = scale;


### PR DESCRIPTION
Tested, up to 706 instructions and 98 registers.
For Expert Sleepers Disting-NT 1.5 beta release, able to convert Spin ASM into C.